### PR TITLE
Unblock withdrawals; proportional loss; Gauntlet hash; docs

### DIFF
--- a/contracts/hyperstaking/HyperStakingInit.sol
+++ b/contracts/hyperstaking/HyperStakingInit.sol
@@ -67,9 +67,6 @@ contract HyperStakingInit is AccessControlEnumerableUpgradeable, ReentrancyGuard
         // withdraw delay, by default 3 days - 259200 seconds
         v.defaultWithdrawDelay = 259200;
 
-        // default withdraw claim tolerance
-        v.allowedWithdrawLoss = 2e16; // 2% with 1e18 precision
-
         // initialize Lockbox
         require(lockboxMailbox != address(0), ZeroAddress());
         LockboxData storage box = v.lockboxData;

--- a/contracts/hyperstaking/facets/AllocationFacet.sol
+++ b/contracts/hyperstaking/facets/AllocationFacet.sol
@@ -12,6 +12,7 @@ import {
 } from "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 import {Currency, CurrencyHandler} from "../libraries/CurrencyHandler.sol";
 import {
@@ -27,6 +28,7 @@ import {
 contract AllocationFacet is IAllocation, HyperStakingAcl, ReentrancyGuardUpgradeable {
     using SafeERC20 for IERC20Metadata;
     using CurrencyHandler for Currency;
+    using Math for uint256;
 
     //============================================================================================//
     //                                      Public Functions                                      //
@@ -203,7 +205,7 @@ contract AllocationFacet is IAllocation, HyperStakingAcl, ReentrancyGuardUpgrade
             uint256 capUnits;
             // guard, div by zero, if everything is already queued
             if (availableStake > 0) {
-                capUnits = si.totalAllocation * stake / availableStake;
+                capUnits = si.totalAllocation.mulDiv(stake, availableStake);
             }
 
             // enforces proportional exits under loss

--- a/contracts/hyperstaking/facets/AllocationFacet.sol
+++ b/contracts/hyperstaking/facets/AllocationFacet.sol
@@ -193,6 +193,8 @@ contract AllocationFacet is IAllocation, HyperStakingAcl, ReentrancyGuardUpgrade
             allocation = stake;
         } else {
             // what we would like to exit to cover 'stake' at current price/slippage
+            // previewAllocation rounds up to the nearest whole share, which can result in an allocation
+            // that is one unit higher than the actual available shares. To ensure the requested exit stake
             uint256 need = IStrategy(strategy).previewAllocation(stake);
 
             // stake still available to queue (excludes already-queued exits)
@@ -204,7 +206,8 @@ contract AllocationFacet is IAllocation, HyperStakingAcl, ReentrancyGuardUpgrade
                 capUnits = si.totalAllocation * stake / availableStake;
             }
 
-            // min(need, capUnits) fix +1 ceil and enforces proportional exits under loss
+            // enforces proportional exits under loss
+            // min(need, capUnits) also fix +1 ceil from previewAllocation
             allocation = need <= capUnits ? need : capUnits;
 
             // save non-direct stake information

--- a/contracts/hyperstaking/facets/DepositFacet.sol
+++ b/contracts/hyperstaking/facets/DepositFacet.sol
@@ -147,6 +147,7 @@ contract DepositFacet is IDeposit, HyperStakingAcl, ReentrancyGuardUpgradeable, 
             } else {
                 depositType = DepositType.Active;
                 v.stakeInfo[c.strategy].totalStake -= stake;
+                v.stakeInfo[c.strategy].pendingExitStake -= stake;
             }
 
             emit WithdrawClaimed(c.strategy, msg.sender, to, stake, exitAmount, depositType);

--- a/contracts/hyperstaking/facets/HyperFactoryFacet.sol
+++ b/contracts/hyperstaking/facets/HyperFactoryFacet.sol
@@ -137,7 +137,8 @@ contract HyperFactoryFacet is IHyperFactory, HyperStakingAcl, ReentrancyGuardUpg
             // active staking
             v.stakeInfo[strategy] = StakeInfo({
                 totalStake: 0,
-                totalAllocation: 0
+                totalAllocation: 0,
+                pendingExitStake: 0
             });
         }
     }

--- a/contracts/hyperstaking/interfaces/IDeposit.sol
+++ b/contracts/hyperstaking/interfaces/IDeposit.sol
@@ -61,12 +61,6 @@ interface IDeposit {
         uint256 newDelay
     );
 
-    event AllowedWithdrawLossSet(
-        address indexed stakingManager,
-        uint256 previousAllowedLoss,
-        uint256 newAllowedLoss
-    );
-
     //============================================================================================//
     //                                          Errors                                            //
     //============================================================================================//
@@ -100,13 +94,6 @@ interface IDeposit {
 
     /// @notice Thrown when trying to set too high withdraw delay
     error WithdrawDelayTooHigh(uint64 newDelay);
-
-    /// @notice Thrown when attempting to set withdraw loss tolerance above 100%
-    error WithdrawLossTooHigh();
-
-    /// @notice Thrown when withdraw loss exceeds the allowed tolerance
-    error WithdrawLossExceeded(uint256 expected, uint256 actual);
-
 
     //============================================================================================//
     //                                          Mutable                                           //
@@ -179,12 +166,6 @@ interface IDeposit {
      */
     function setWithdrawDelay(uint64 newDelay) external;
 
-    /**
-      * @notice Sets the allowed loss tolerance for exit claims
-      * @dev (1e18 = 100%)
-      */
-    function setAllowedWithdrawLoss(uint256 newAllowedLoss) external;
-
     /// @notice Pauses stake functionalities
     function pauseDeposit() external;
 
@@ -200,9 +181,6 @@ interface IDeposit {
 
     /// @notice Cool‑down in seconds that must elapse before a queued claim can be withdrawn
     function withdrawDelay() external view returns (uint64);
-
-    /// @notice Returns the current allowed loss tolerance
-    function allowedWithdrawLoss() external view returns (uint256);
 
     /// @notice Returns claims for given requestIds; chooses fee/user mapping by flag
     function pendingWithdraws(uint256[] calldata requestIds)

--- a/contracts/hyperstaking/libraries/LibHyperStaking.sol
+++ b/contracts/hyperstaking/libraries/LibHyperStaking.sol
@@ -41,6 +41,7 @@ struct DirectStakeInfo {
 struct StakeInfo {
     uint256 totalStake;
     uint256 totalAllocation;
+    uint256 pendingExitStake; // stake already queued to leave, not yet claimed
 }
 
 // @param strategy That produced this claim

--- a/contracts/hyperstaking/libraries/LibHyperStaking.sol
+++ b/contracts/hyperstaking/libraries/LibHyperStaking.sol
@@ -107,9 +107,6 @@ struct HyperStakingStorage {
     /// @notice Global delay, in seconds, that must elapse after a claim is queued
     uint64 defaultWithdrawDelay;
 
-    /// @notice Allowed loss tolerance for exit claims
-    uint256 allowedWithdrawLoss;
-
     /// @notice Next request ID for strategy operations
     uint256 nextRequestId;
 

--- a/contracts/hyperstaking/strategies/GauntletStrategy.sol
+++ b/contracts/hyperstaking/strategies/GauntletStrategy.sol
@@ -54,7 +54,7 @@ contract GauntletStrategy is AbstractStrategy {
     /// @dev Equal to the minTokensOut passed to Aera for this request preserved as a record
     mapping(uint256 requestId => uint256 minStakeOut) public recordedExit;
 
-    // @notice Keeps the last used deadline for Aera requests
+    /// @notice Keeps the last used deadline for Aera requests
     uint256 private _lastAeraDeadline;
 
     //============================================================================================//

--- a/contracts/hyperstaking/strategies/GauntletStrategy.sol
+++ b/contracts/hyperstaking/strategies/GauntletStrategy.sol
@@ -54,6 +54,9 @@ contract GauntletStrategy is AbstractStrategy {
     /// @dev Equal to the minTokensOut passed to Aera for this request preserved as a record
     mapping(uint256 requestId => uint256 minStakeOut) public recordedExit;
 
+    // @notice Keeps the last used deadline for Aera requests
+    uint256 private _lastAeraDeadline;
+
     //============================================================================================//
     //                                          Events                                            //
     //============================================================================================//
@@ -345,8 +348,16 @@ contract GauntletStrategy is AbstractStrategy {
     }
 
     /// @dev Returns execution deadline by adding the configured offset to the current block time
-    function _aeraDeadline() internal view returns (uint256) {
-        return block.timestamp + aeraConfig.deadlineOffset;
+    ///      If multiple requests are made in the same block, bumps by +1 to keep uniqueness
+    function _aeraDeadline() internal returns (uint256 deadline) {
+        deadline = block.timestamp + aeraConfig.deadlineOffset;
+
+        // ensure strict monotonic increase to avoid hash collisions
+        if (deadline <= _lastAeraDeadline) {
+            deadline = _lastAeraDeadline + 1;
+        }
+
+        _lastAeraDeadline = deadline;
     }
 
     /// @notice Calculate the request hash in the same way as in the Area Provisioner contract

--- a/docs/hyperstaking-overview.md
+++ b/docs/hyperstaking-overview.md
@@ -1,0 +1,33 @@
+## HyperStaking (High-Level Overview)
+
+HyperStaking is a modular, cross-chain staking framework built on the **Diamond Proxy (ERC-2535)** standard.  
+It enables multi-pool staking with flexible asset support (native coins, ERC-20) and can be extended to  
+real-world assets (RWAs) such as tokenized real estate, treasuries, or commodities. All staking and yield  
+operations across many EVM chains are ultimately settled on the **Lumia Chain**, which acts as the hub.
+
+**Core Mechanics:**
+
+* Users stake tokens (ETH, stablecoins, etc.) on origin chains.  
+* **Hyperlane** relays stake and redemption events to the Lumia Chain, where **ERC-4626 vault shares**  
+  are minted to represent deposits plus accrued yield.  
+* Strategies (e.g., Dinero, Curve, Superform) generate yield and report back, which automatically 
+  updates the **price per share** of ERC-4626 vault tokens.  
+* Both synchronous and asynchronous flows are supported, enabling instant exits or delayed redemption  
+  requests with buffers for liquidity management.  
+
+**Integrations:**
+
+* **Dinero Protocol**: yield via Pirex/pxETH/apxETH.  
+* **Superform**: USDC -> SuperUSDC strategy (ERC-4626/1155 flows).  
+* **Gauntlet (Aera)**: USDC strategy via Aera multi-depositor vaults (gtUSDa).  
+* **Curve**: swaps between stablecoins (e.g., USDT -> USDC) combined with Superform.  
+* **Hyperlane**: secure cross-chain messaging for stake synchronization and redemption flow.  
+
+**Extendability:**
+
+* Flexible **Strategies interface** allows plugging in and supporting many types of investments,  
+  both crypto-native and RWA, in synchronous or asynchronous mode.  
+* New strategies can be added as independent modules without redeploying the core.  
+* Any ERC-20 or native asset can be supported; NFTs can be wrapped.  
+* The same vault/share model ensures a unified user experience, regardless of asset type.  
+* Governance/ACL allows controlled upgrades without interrupting users, with potential for DAO-based management.  

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^5.2.1",
         "ethers": "^6.13.2",
+        "fast-check": "^4.3.0",
         "hardhat": "^2.24.0",
         "hardhat-contract-sizer": "^2.10.0",
         "hardhat-ignore-warnings": "^0.2.12",
@@ -5381,6 +5382,29 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "node_modules/fast-check": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.3.0.tgz",
+      "integrity": "sha512-JVw/DJSxVKl8uhCb7GrwanT9VWsCIdBkK3WpP37B/Au4pyaspriSjtrY2ApbSFwTg3ViPfniT13n75PhzE7VEQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -8722,6 +8746,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+      "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.13.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^5.2.1",
     "ethers": "^6.13.2",
+    "fast-check": "^4.3.0",
     "hardhat": "^2.24.0",
     "hardhat-contract-sizer": "^2.10.0",
     "hardhat-ignore-warnings": "^0.2.12",

--- a/test/shared.ts
+++ b/test/shared.ts
@@ -7,7 +7,7 @@ import HyperStakingModule from "../ignition/modules/HyperStaking";
 import LumiaDiamondModule from "../ignition/modules/LumiaDiamond";
 import OneChainMailboxModule from "../ignition/modules/test/OneChainMailbox";
 import SuperformMockModule from "../ignition/modules/test/SuperformMock";
-import CurveMockModule from "../ignition/modules/test/CurveMock.ts";
+import CurveMockModule from "../ignition/modules/test/CurveMock";
 
 import TestERC20Module from "../ignition/modules/test/TestERC20";
 import ReserveStrategyModule from "../ignition/modules/test/MockReserveStrategy";

--- a/test/unit/Aera.test.ts
+++ b/test/unit/Aera.test.ts
@@ -1323,9 +1323,9 @@ describe("Aera", function () {
       expect(r3.minOut).to.be.lte(r3.amount);
 
       // Under fixed price/slippage, proportionality holds within a wei or two
-      // r2 is about 2× r1; r3 about 3× r1
-      expect((r2.minOut - 2n * r1.minOut) < 2n).to.equal(true);
-      expect((r3.minOut - 3n * r1.minOut) < 3n).to.equal(true);
+      // Each 1/3 redemption should yield a similar amount of tokens.
+      expect(r1.minOut).to.be.closeTo(r2.minOut, 2n);
+      expect(r3.minOut).to.be.closeTo(r2.minOut, 2n);
 
       // No last-claim penalty: the largest chunk does not get worse treatment
       const minPart = r1.minOut < r2.minOut ? r1.minOut : r2.minOut;

--- a/test/unit/Aera.test.ts
+++ b/test/unit/Aera.test.ts
@@ -801,12 +801,7 @@ describe("Aera", function () {
       );
 
       // because previewAllocation rounds up, we may need to correct by 1 unit
-      let expectedExitShares = await gauntletStrategy.previewAllocation(exitAmount) - 1n;
-
-      // 1 off-by-one correction if necessary
-      if (expectedExitShares > siAfterReport.totalAllocation) {
-        expectedExitShares -= 1n;
-      }
+      const expectedExitShares = await gauntletStrategy.previewAllocation(exitAmount) - 1n;
 
       const cfg = await gauntletStrategy.aeraConfig();
       const deadline = BigInt(now + 60) + cfg.deadlineOffset;

--- a/test/unit/Aera.test.ts
+++ b/test/unit/Aera.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import { ethers, ignition } from "hardhat";
 import { time, loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers";
-import { parseUnits, Log, Contract, ZeroAddress, parseEther } from "ethers";
+import { parseUnits, Log, Contract, ZeroAddress } from "ethers";
 import * as shared from "../shared";
 import { TokenDetailsStruct } from "../../typechain-types/contracts/external/aera/Provisioner";
 import { AeraConfigStruct } from "../../typechain-types/contracts/hyperstaking/strategies/GauntletStrategy";
@@ -434,7 +434,7 @@ describe("Aera", function () {
       } = await loadFixture(deployHyperStaking);
 
       const { deposit, allocation, realAssets, testUSDC } = hyperStaking;
-      const { alice, stakingManager, strategyManager } = signers;
+      const { alice, strategyManager } = signers;
 
       // --- configure slippage back to 3% ---
       const cfg = await gauntletStrategy.aeraConfig();
@@ -445,9 +445,6 @@ describe("Aera", function () {
         slippageBps: 300,
         isFixedPrice: cfg.isFixedPrice,
       } as AeraConfigStruct);
-
-      // increase allowed withdraw loss to 6% (to allow for 3% in and 3% out)
-      await deposit.connect(stakingManager).setAllowedWithdrawLoss(parseEther("0.06"));
 
       const stakeAmount = parseUnits("1000", 6);
       await testUSDC.connect(alice).approve(deposit, stakeAmount);


### PR DESCRIPTION
This PR removes `allowedWithdrawLoss` and settles realized loss at market price, unblocking withdrawals that previously reverted when loss > tolerance at a stage where nothing could be done. It also fixes a +1 wei edge case on final redemption.

Loss is now handled proportionally: exits are capped by a fair share of available allocation units using `pendingExitStake`. Gains remain with the stake amount, and the report is used for income distribution.

Adds tests, including **fast-check** fuzz tests covering slippage, redeem ratios, and up/down price moves.

Handles a rare Gauntlet strategy situation: if two requests are created in the same block, they share the same deadline and can cause a hash collision. Ensures unique Aera request hashes by bumping the deadline when needed.

Docs: add HyperStaking overview

Resolves: #1 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes withdraw-loss tolerance in favor of market-priced withdrawals with proportional exit capping, adds monotonic Aera deadlines to avoid Gauntlet hash collisions, updates storage/accounting, and adds docs and fuzz tests.
> 
> - **Core/Withdrawals**:
>   - Remove `allowedWithdrawLoss` tolerance entirely: delete storage, setter/getter, events, errors, and claim-time checks; initialize without it.
>   - Withdrawals now settle at market price; no reverts on loss.
> - **Allocation/Exits**:
>   - Enforce proportional exits under loss using `pendingExitStake` cap: in `AllocationFacet._leave` compute `need = previewAllocation(stake)`, cap by `si.totalAllocation * stake / (si.totalStake - si.pendingExitStake)`, and increment `si.pendingExitStake`.
>   - Decrement `pendingExitStake` on claim in `DepositFacet`.
> - **Storage/Init**:
>   - Extend `StakeInfo` with `pendingExitStake` and initialize in `HyperFactoryFacet`.
>   - Remove `allowedWithdrawLoss` from `LibHyperStaking` storage and `HyperStakingInit`.
> - **Gauntlet Strategy**:
>   - Make `_aeraDeadline()` monotonic with `_lastAeraDeadline` to avoid same-block request-hash collisions.
> - **Tests/Deps**:
>   - Add property-based tests with `fast-check`; broad gain/loss, slippage, and multi-redeem scenarios; adjust unit tests to new exit logic and off-by-one fixes.
>   - Fix import path `CurveMock` and minor test updates.
> - **Docs**:
>   - Add `docs/hyperstaking-overview.md` high-level overview.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03f585f768a1e052de0e0084ebf99ec695867321. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->