### PR TITLE
Migrate strategies to UUPS

### DIFF
--- a/contracts/hyperstaking/HyperStakingAcl.sol
+++ b/contracts/hyperstaking/HyperStakingAcl.sol
@@ -19,6 +19,7 @@ import {LibAcl} from "./libraries/LibAcl.sol";
  *      - `Staking Manager`: Oversees staking operations
  *      - `Vault Manager`: Handles vaults
  *      - `Strategy Manager`: Handles external strategies
+ *      - `Strategy Upgrader`: Handle upgrades for external strategies
  *
  *      Utilizes OpenZeppelin's AccessControlEnumerableUpgradeable, which now supports
  *      EIP-7201 namespace storage, making it compatible with Diamond Proxy architecture
@@ -62,6 +63,14 @@ contract HyperStakingAcl is AccessControlEnumerableUpgradeable, IHyperStakingRol
         _;
     }
 
+    /// @dev Only allows access for the `Strategy Upgrader` role
+    modifier onlyStrategyUpgrader() {
+        if (!hasRole(STRATEGY_UPGRADER_ROLE(), msg.sender)) {
+            revert OnlyStrategyUpgrader();
+        }
+        _;
+    }
+
     //============================================================================================//
     //                                      Public Functions                                      //
     //============================================================================================//
@@ -71,6 +80,11 @@ contract HyperStakingAcl is AccessControlEnumerableUpgradeable, IHyperStakingRol
     /// @inheritdoc IHyperStakingRoles
     function hasStrategyManagerRole(address account) external view returns (bool) {
         return hasRole(STRATEGY_MANAGER_ROLE(), account);
+    }
+
+    /// @inheritdoc IHyperStakingRoles
+    function hasStrategyUpgraderRole(address account) external view returns (bool) {
+        return hasRole(STRATEGY_UPGRADER_ROLE(), account);
     }
 
     // ---
@@ -85,5 +99,9 @@ contract HyperStakingAcl is AccessControlEnumerableUpgradeable, IHyperStakingRol
 
     function STRATEGY_MANAGER_ROLE() public pure returns (bytes32) {
         return LibAcl.STRATEGY_MANAGER_ROLE;
+    }
+
+    function STRATEGY_UPGRADER_ROLE() public pure returns (bytes32) {
+        return LibAcl.STRATEGY_UPGRADER_ROLE;
     }
 }

--- a/contracts/hyperstaking/HyperStakingInit.sol
+++ b/contracts/hyperstaking/HyperStakingInit.sol
@@ -56,6 +56,7 @@ contract HyperStakingInit is AccessControlEnumerableUpgradeable, ReentrancyGuard
         _grantRole(LibAcl.STAKING_MANAGER_ROLE, initStakingManager);
         _grantRole(LibAcl.VAULT_MANAGER_ROLE, initVaultManager);
         _grantRole(LibAcl.STRATEGY_MANAGER_ROLE, initStrategyManager);
+        _grantRole(LibAcl.STRATEGY_UPGRADER_ROLE, msg.sender);
 
         // adding IAccessControlEnumerable to supportedInterfaces
         LibDiamond.DiamondStorage storage ds = LibDiamond.diamondStorage();

--- a/contracts/hyperstaking/interfaces/IHyperStakingRoles.sol
+++ b/contracts/hyperstaking/interfaces/IHyperStakingRoles.sol
@@ -16,15 +16,20 @@ interface IHyperStakingRoles {
     error OnlyStakingManager();
     error OnlyVaultManager();
     error OnlyStrategyManager();
+    error OnlyStrategyUpgrader();
 
     //============================================================================================//
     //                                           View                                             //
     //============================================================================================//
 
-    /// @notice Helper used in external strategies, checks if user has the StrategyManager role
+    /// @notice Helper used in external strategies
     function hasStrategyManagerRole(address user) external view returns (bool);
+
+    /// @notice Helper used in external strategies
+    function hasStrategyUpgraderRole(address user) external view returns (bool);
 
     function STAKING_MANAGER_ROLE() external view returns (bytes32);
     function VAULT_MANAGER_ROLE() external view returns (bytes32);
     function STRATEGY_MANAGER_ROLE() external view returns (bytes32);
+    function STRATEGY_UPGRADER_ROLE() external view returns (bytes32);
 }

--- a/contracts/hyperstaking/libraries/LibAcl.sol
+++ b/contracts/hyperstaking/libraries/LibAcl.sol
@@ -7,4 +7,5 @@ library LibAcl {
     bytes32 public constant STAKING_MANAGER_ROLE = keccak256("STAKING_MANAGER_ROLE");
     bytes32 public constant VAULT_MANAGER_ROLE = keccak256("VAULT_MANAGER_ROLE");
     bytes32 public constant STRATEGY_MANAGER_ROLE = keccak256("STRATEGY_MANAGER_ROLE");
+    bytes32 public constant STRATEGY_UPGRADER_ROLE = keccak256("STRATEGY_UPGRADER_ROLE");
 }

--- a/contracts/hyperstaking/strategies/AbstractStrategy.sol
+++ b/contracts/hyperstaking/strategies/AbstractStrategy.sol
@@ -101,7 +101,9 @@ abstract contract AbstractStrategy is IStrategy, Initializable, UUPSUpgradeable 
     }
 
     /// @dev Authorize upgrades for UUPS pattern
-    function _authorizeUpgrade(address newImplementation) internal override onlyStrategyUpgrader {}
+    function _authorizeUpgrade(address newImplementation) internal view override onlyStrategyUpgrader {
+        require(newImplementation != address(0), ZeroAddress());
+    }
 
     //============================================================================================//
     //                                      Public Functions                                      //

--- a/contracts/hyperstaking/strategies/DineroStrategy.sol
+++ b/contracts/hyperstaking/strategies/DineroStrategy.sol
@@ -17,6 +17,9 @@ import {PirexIntegration} from "./integrations/PirexIntegration.sol";
 contract DineroStrategy is AbstractStrategy, PirexIntegration {
     using SafeERC20 for IERC20;
 
+    /// Storage gap for upgradeability. Must remain the last state variable
+    uint256[50] private __gap;
+
     //============================================================================================//
     //                                          Errors                                            //
     //============================================================================================//
@@ -24,15 +27,18 @@ contract DineroStrategy is AbstractStrategy, PirexIntegration {
     error BadAllocationValue();
 
     //============================================================================================//
-    //                                        Constructor                                         //
+    //                                        Initialize                                          //
     //============================================================================================//
 
-    constructor(
+    function initialize (
         address diamond_,
         address pxEth_,
         address pirexEth_,
         address autoPxEth_
-    ) AbstractStrategy(diamond_) PirexIntegration(pxEth_, pirexEth_, autoPxEth_) { }
+    ) public initializer {
+        __AbstractStrategy_init(diamond_);
+        __PirexIntegration_init(pxEth_, pirexEth_, autoPxEth_);
+    }
 
     //============================================================================================//
     //                                      Public Functions                                      //

--- a/contracts/hyperstaking/strategies/DirectStakeStrategy.sol
+++ b/contracts/hyperstaking/strategies/DirectStakeStrategy.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity =0.8.27;
 
-import {StrategyRequest, StrategyKind, IStrategy} from "../interfaces/IStrategy.sol";
+import {StrategyKind, StrategyRequest, IStrategy} from "../interfaces/IStrategy.sol";
 import {AbstractStrategy} from "./AbstractStrategy.sol";
 
 import {Currency, CurrencyHandler} from "../libraries/CurrencyHandler.sol";
@@ -18,6 +18,9 @@ contract DirectStakeStrategy is AbstractStrategy {
     /// Main currency used for staking
     Currency private currency;
 
+    /// Storage gap for upgradeability. Must remain the last state variable
+    uint256[50] private __gap;
+
     //============================================================================================//
     //                                          Errors                                            //
     //============================================================================================//
@@ -25,13 +28,14 @@ contract DirectStakeStrategy is AbstractStrategy {
     error DirectStakeMisused();
 
     //============================================================================================//
-    //                                        Constructor                                         //
+    //                                        Initialize                                          //
     //============================================================================================//
 
-    constructor(
+    function initialize (
         address diamond_,
         Currency memory currency_
-    ) AbstractStrategy(diamond_) {
+    ) public initializer {
+        __AbstractStrategy_init(diamond_);
         currency = currency_;
     }
 

--- a/contracts/hyperstaking/strategies/GauntletStrategy.sol
+++ b/contracts/hyperstaking/strategies/GauntletStrategy.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity =0.8.27;
 
+// solhint-disable var-name-mixedcase
+
 import {StrategyKind, StrategyRequest, IStrategy} from "../interfaces/IStrategy.sol";
 import {AbstractStrategy} from "./AbstractStrategy.sol";
 import {LumiaGtUSDa} from "./tokens/LumiaGtUSDa.sol";
@@ -32,19 +34,19 @@ contract GauntletStrategy is AbstractStrategy {
     AeraConfig public aeraConfig;
 
     /// @notice Address of the Gauntlet derived token, used as allocation for the HyperStaking
-    LumiaGtUSDa public immutable LUMIA_GTUSDA;
+    LumiaGtUSDa public LUMIA_GTUSDA;
 
     /// @notice Stake token accepted by the strategy (input currency)
-    IERC20 public immutable STAKE_TOKEN;
+    IERC20 public STAKE_TOKEN;
 
     /// @notice Aera Provisioner used to submit deposit and redeem requests
-    Provisioner public immutable AERA_PROVISIONER;
+    Provisioner public AERA_PROVISIONER;
 
     /// @notice The price calculator contract taken from aera provisioner
-    IPriceAndFeeCalculator public immutable AERA_PRICE;
+    IPriceAndFeeCalculator public AERA_PRICE;
 
     /// @notice The vault contract taken from aera provisioner (actual gtUSDa)
-    address public immutable AERA_VAULT;
+    address public AERA_VAULT;
 
     /// @notice Recorded allocation amounts per requestId
     /// @dev Stores the minimum allocation units that were guaranteed when the request was created
@@ -56,6 +58,9 @@ contract GauntletStrategy is AbstractStrategy {
 
     /// @notice Keeps the last used deadline for Aera requests
     uint256 private _lastAeraDeadline;
+
+    /// Storage gap for upgradeability. Must remain the last state variable
+    uint256[50] private __gap;
 
     //============================================================================================//
     //                                          Events                                            //
@@ -81,14 +86,16 @@ contract GauntletStrategy is AbstractStrategy {
     error InvalidConfig();
 
     //============================================================================================//
-    //                                        Constructor                                         //
+    //                                        Initialize                                          //
     //============================================================================================//
 
-    constructor(
+    function initialize (
         address diamond_,
         address stakeToken_, // (gtUSDa uses USDC as deposit, in time of writing)
         address aeraProvisioner_
-    ) AbstractStrategy(diamond_) {
+    ) public initializer {
+        __AbstractStrategy_init(diamond_);
+
         require(stakeToken_ != address(0), ZeroAddress());
 
         // deploys new ERC20 token owned by this strategy

--- a/contracts/hyperstaking/strategies/SuperformStrategy.sol
+++ b/contracts/hyperstaking/strategies/SuperformStrategy.sol
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity =0.8.27;
 
+// solhint-disable var-name-mixedcase
+// solhint-disable func-name-mixedcase
+
 import {StrategyKind, StrategyRequest, IStrategy} from "../interfaces/IStrategy.sol";
 import {AbstractStrategy} from "./AbstractStrategy.sol";
 
@@ -22,19 +25,22 @@ contract SuperformStrategy is AbstractStrategy, IERC1155Receiver {
     using SafeERC20 for IERC20;
 
     /// Address of the designated SuperVault
-    address public immutable SUPER_VAULT;
+    address public SUPER_VAULT;
 
     /// Specific superform used by this strategy
-    uint256 public immutable SUPERFORM_ID;
+    uint256 public SUPERFORM_ID;
 
     /// Token address used in allocation
-    IERC20 public immutable SUPERFORM_INPUT_TOKEN;
+    IERC20 public SUPERFORM_INPUT_TOKEN;
 
     /// Superform integration - (diamond facet)
     ISuperformIntegration public superformIntegration;
 
     /// SuperPositions contract address
     ISuperPositions public superPositions;
+
+    /// Storage gap for upgradeability. Must remain the last state variable
+    uint256[50] private __gap;
 
     //============================================================================================//
     //                                          Errors                                            //
@@ -45,14 +51,24 @@ contract SuperformStrategy is AbstractStrategy, IERC1155Receiver {
     error InvalidStakeToken(address expected, address provided);
 
     //============================================================================================//
-    //                                        Constructor                                         //
+    //                                        Initialize                                          //
     //============================================================================================//
 
-    constructor(
+    // Used when strategy is the final strategy
+    function initialize (
         address diamond_,
         address superVault_,
         address stakeToken_ // SuperUSDC supports USDC as deposit, asset is checked
-    ) AbstractStrategy(diamond_) {
+    ) public virtual initializer {
+        __AbstractStrategy_init(diamond_);
+        __SuperformStrategy_init(diamond_, superVault_, stakeToken_);
+    }
+
+    function __SuperformStrategy_init(
+        address diamond_,
+        address superVault_,
+        address stakeToken_
+    ) internal onlyInitializing {
         require(superVault_ != address(0), ZeroAddress());
         require(stakeToken_ != address(0), ZeroAddress());
 

--- a/contracts/hyperstaking/strategies/SwapSuperStrategy.sol
+++ b/contracts/hyperstaking/strategies/SwapSuperStrategy.sol
@@ -15,16 +15,19 @@ contract SwapSuperStrategy is SuperformStrategy {
     using SafeERC20 for IERC20;
 
     /// The actual token address used in allocation, must be swaped before it can be used with superform
-    IERC20 public immutable CURVE_INPUT_TOKEN;
+    IERC20 public CURVE_INPUT_TOKEN;
 
     /// 3Pool, etc.
-    address public immutable CURVE_POOL;
+    address public CURVE_POOL;
 
     /// Curve integration - (diamond facet)
     ICurveIntegration public curveIntegration;
 
      /// @dev Maximum slippage in basis points (1 bp = 0.01 %)
     uint256 private slippageBps;
+
+    /// Storage gap for upgradeability. Must remain the last state variable
+    uint256[50] private __gap;
 
     //============================================================================================//
     //                                          Events                                            //
@@ -52,16 +55,19 @@ contract SwapSuperStrategy is SuperformStrategy {
     error SlippageTooHigh();
 
     //============================================================================================//
-    //                                        Constructor                                         //
+    //                                        Initialize                                          //
     //============================================================================================//
 
-    constructor(
+    function initialize (
         address diamond_,
         address curveInputToken_,
         address curvePool_,
         address superVault_,
         address superformInputToken_ // This contract takes different stake/deposit token than superform
-    ) SuperformStrategy(diamond_, superVault_, superformInputToken_) {
+    ) public initializer {
+        __AbstractStrategy_init(diamond_);
+        __SuperformStrategy_init(diamond_, superVault_, superformInputToken_);
+
         require(curveInputToken_ != address(0), ZeroAddress());
         require(curvePool_ != address(0), ZeroAddress());
 

--- a/contracts/hyperstaking/strategies/integrations/PirexIntegration.sol
+++ b/contracts/hyperstaking/strategies/integrations/PirexIntegration.sol
@@ -1,25 +1,31 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity =0.8.27;
 
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
-import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+// solhint-disable var-name-mixedcase
+// solhint-disable func-name-mixedcase
+
+import {IERC20, SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
 import {PirexEth} from "../../../external/pirex/PirexEth.sol";
 import {AutoPxEth} from "../../../external/pirex/AutoPxEth.sol";
 
 import {DataTypes} from "../../../external/pirex/libraries/DataTypes.sol";
 
-contract PirexIntegration {
+contract PirexIntegration is Initializable {
     using SafeERC20 for IERC20;
 
     /// PxEth (ERC20) contract address
-    address public immutable PX_ETH;
+    address public PX_ETH;
 
     /// PirexEth contract address
-    address public immutable PIREX_ETH;
+    address public PIREX_ETH;
 
     /// AutoPxEth (ERC4626) contract address
-    address public immutable AUTO_PX_ETH;
+    address public AUTO_PX_ETH;
+
+    /// Storage gap for upgradeability. Must remain the last state variable
+    uint256[50] private __gap;
 
     //============================================================================================//
     //                                          Events                                            //
@@ -49,14 +55,14 @@ contract PirexIntegration {
     error ZeroAddressPx();
 
     //============================================================================================//
-    //                                        Constructor                                         //
+    //                                        Initialize                                          //
     //============================================================================================//
 
-    constructor(
+    function __PirexIntegration_init(
         address pxEth_,
         address pirexEth_,
         address autoPxEth_
-    ) {
+    ) public onlyInitializing {
         require(pxEth_ != address(0), ZeroAddressPx());
         require(pirexEth_ != address(0), ZeroAddressPx());
         require(autoPxEth_ != address(0), ZeroAddressPx());

--- a/contracts/hyperstaking/strategies/integrations/PirexIntegration.sol
+++ b/contracts/hyperstaking/strategies/integrations/PirexIntegration.sol
@@ -62,7 +62,7 @@ contract PirexIntegration is Initializable {
         address pxEth_,
         address pirexEth_,
         address autoPxEth_
-    ) public onlyInitializing {
+    ) internal onlyInitializing {
         require(pxEth_ != address(0), ZeroAddressPx());
         require(pirexEth_ != address(0), ZeroAddressPx());
         require(autoPxEth_ != address(0), ZeroAddressPx());

--- a/contracts/test/ArtifactImports.sol
+++ b/contracts/test/ArtifactImports.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity =0.8.27;
+
+// solhint-disable no-unused-import
+
+// This file exists to force Hardhat to compile external contracts
+// so ABIs are available for tests, scripts, and ignition
+
+// solmate
+import {RolesAuthority} from "solmate/auth/authorities/RolesAuthority.sol";
+
+// openzeppelin
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";

--- a/contracts/test/MockReserveStrategy.sol
+++ b/contracts/test/MockReserveStrategy.sol
@@ -35,6 +35,10 @@ contract MockReserveStrategy is AbstractStrategy {
     /// Price of the asset
     uint256 public assetReserve;
 
+    //============================================================================================//
+    //                                          Errors                                            //
+    //============================================================================================//
+
     error MissingCollateral();
 
     //============================================================================================//
@@ -71,16 +75,18 @@ contract MockReserveStrategy is AbstractStrategy {
     );
 
     //============================================================================================//
-    //                                        Constructor                                         //
+    //                                        Initialize                                          //
     //============================================================================================//
 
     // @param assetPrice_ should be provided with 18 decimal precision
-    constructor(
+    function initialize (
         address diamond_,
         Currency memory stake_,
         IERC20Metadata revenueAsset_,
         uint256 assetPrice_
-    ) AbstractStrategy(diamond_) {
+    ) public initializer {
+        __AbstractStrategy_init(diamond_);
+
         stake = stake_;
         revenueAsset = address(revenueAsset_);
         assetPrice = assetPrice_;

--- a/contracts/test/MockReserveStrategy.sol
+++ b/contracts/test/MockReserveStrategy.sol
@@ -35,6 +35,9 @@ contract MockReserveStrategy is AbstractStrategy {
     /// Price of the asset
     uint256 public assetReserve;
 
+    /// Storage gap for upgradeability. Must remain the last state variable
+    uint256[50] private __gap;
+
     //============================================================================================//
     //                                          Errors                                            //
     //============================================================================================//

--- a/contracts/test/RolesAuthorityImport.sol
+++ b/contracts/test/RolesAuthorityImport.sol
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.8.27;
-
-// For test purposes only: bring RolesAuthority into Hardhat artifacts
-// solhint-disable-next-line no-unused-import
-import {RolesAuthority} from "solmate/auth/authorities/RolesAuthority.sol";

--- a/ignition/modules/DineroStrategy.ts
+++ b/ignition/modules/DineroStrategy.ts
@@ -12,9 +12,21 @@ const DineroStrategyModule = buildModule("DineroStrategyModule", (m) => {
   const pirexEth = m.getParameter("pirexEth", PIREX_ETH_ADDRESS);
   const autoPxEth = m.getParameter("autoPxEth", AUTO_PX_ETH_ADDRESS);
 
-  const dineroStrategy = m.contract("DineroStrategy", [diamond, pxEth, pirexEth, autoPxEth]);
+  // deploy implementation
+  const impl = m.contract("DineroStrategy", [], { id: "impl" });
 
-  return { dineroStrategy };
+  // encode initializer calldata
+  const initCalldata = m.encodeFunctionCall(impl, "initialize", [
+    diamond, pxEth, pirexEth, autoPxEth,
+  ]);
+
+  // deploy ERC1967Proxy with init data
+  const proxy = m.contract("ERC1967Proxy", [impl, initCalldata]);
+
+  // treat the proxy as DineroStrategy
+  const dineroStrategy = m.contractAt("DineroStrategy", proxy);
+
+  return { proxy, dineroStrategy };
 });
 
 export default DineroStrategyModule;

--- a/ignition/modules/DirectStakeStrategy.ts
+++ b/ignition/modules/DirectStakeStrategy.ts
@@ -4,10 +4,21 @@ const DirectStakeStrategyModule = buildModule("DirectStakeStrategyModule", (m) =
   const diamond = m.getParameter("diamond", "0x");
   const currencyToken = m.getParameter("currencyToken", "0x");
 
-  const directStakeStrategy = m.contract("DirectStakeStrategy", [
+  // deploy implementation
+  const impl = m.contract("DirectStakeStrategy", [], { id: "impl" });
+
+  // encode initializer calldata
+  const initCalldata = m.encodeFunctionCall(impl, "initialize", [
     diamond, { token: currencyToken },
   ]);
-  return { directStakeStrategy };
+
+  // deploy ERC1967Proxy with init data
+  const proxy = m.contract("ERC1967Proxy", [impl, initCalldata]);
+
+  // treat the proxy as DirectStakeStrategy
+  const directStakeStrategy = m.contractAt("DirectStakeStrategy", proxy);
+
+  return { proxy, directStakeStrategy };
 });
 
 export default DirectStakeStrategyModule;

--- a/ignition/modules/GauntletStrategy.ts
+++ b/ignition/modules/GauntletStrategy.ts
@@ -5,11 +5,21 @@ const GauntletStrategyModule = buildModule("GauntletStrategyModule", (m) => {
   const stakeToken = m.getParameter("stakeToken");
   const aeraProvisioner = m.getParameter("aeraProvisioner");
 
-  const gauntletStrategy = m.contract("GauntletStrategy", [
+  // deploy implementation
+  const impl = m.contract("GauntletStrategy", [], { id: "impl" });
+
+  // encode initializer calldata
+  const initCalldata = m.encodeFunctionCall(impl, "initialize", [
     diamond, stakeToken, aeraProvisioner,
   ]);
 
-  return { gauntletStrategy };
+  // deploy ERC1967Proxy with init data
+  const proxy = m.contract("ERC1967Proxy", [impl, initCalldata]);
+
+  // treat the proxy as GauntletStrategy
+  const gauntletStrategy = m.contractAt("GauntletStrategy", proxy);
+
+  return { proxy, gauntletStrategy };
 });
 
 export default GauntletStrategyModule;

--- a/ignition/modules/SuperformStrategy.ts
+++ b/ignition/modules/SuperformStrategy.ts
@@ -5,9 +5,21 @@ const SuperformStrategyModule = buildModule("SuperformStrategyModule", (m) => {
   const superVault = m.getParameter("superVault");
   const stakeToken = m.getParameter("stakeToken");
 
-  const superformStrategy = m.contract("SuperformStrategy", [diamond, superVault, stakeToken]);
+  // deploy implementation
+  const impl = m.contract("SuperformStrategy", [], { id: "impl" });
 
-  return { superformStrategy };
+  // encode initializer calldata
+  const initCalldata = m.encodeFunctionCall(impl, "initialize", [
+    diamond, superVault, stakeToken,
+  ]);
+
+  // deploy ERC1967Proxy with init data
+  const proxy = m.contract("ERC1967Proxy", [impl, initCalldata]);
+
+  // treat the proxy as SuperformStrategy
+  const superformStrategy = m.contractAt("SuperformStrategy", proxy);
+
+  return { proxy, superformStrategy };
 });
 
 export default SuperformStrategyModule;

--- a/ignition/modules/SwapSuperStrategy.ts
+++ b/ignition/modules/SwapSuperStrategy.ts
@@ -7,11 +7,22 @@ const SwapSuperStrategyModule = buildModule("SwapSuperStrategyModule", (m) => {
   const superVault = m.getParameter("superVault");
   const superformInputToken = m.getParameter("superformInputToken");
 
-  const swapSuperStrategy = m.contract("SwapSuperStrategy", [
+  // deploy implementation
+  const impl = m.contract("SwapSuperStrategy", [], { id: "impl" });
+
+  // encode initializer calldata
+  const fullOverloadName = "initialize(address,address,address,address,address)"; // IGN710
+  const initCalldata = m.encodeFunctionCall(impl, fullOverloadName, [
     diamond, curveInputToken, curvePool, superVault, superformInputToken,
   ]);
 
-  return { swapSuperStrategy };
+  // deploy ERC1967Proxy with init data
+  const proxy = m.contract("ERC1967Proxy", [impl, initCalldata]);
+
+  // treat the proxy as SwapSuperStrategy
+  const swapSuperStrategy = m.contractAt("SwapSuperStrategy", proxy);
+
+  return { proxy, swapSuperStrategy };
 });
 
 export default SwapSuperStrategyModule;

--- a/ignition/modules/test/MockReserveStrategy.ts
+++ b/ignition/modules/test/MockReserveStrategy.ts
@@ -8,17 +8,18 @@ const ReserveStrategyModule = buildModule("ReserveStrategyModule", (m) => {
   const assetPrice = m.getParameter("assetPrice", parseEther("1"));
 
   const impl = m.contract("MockReserveStrategy", [], { id: "impl" });
-  const proxy = m.contract("ERC1967Proxy", [impl, "0x"]);
 
-  const reserveStrategy = m.contractAt("MockReserveStrategy", proxy);
-
-  // Initialize via the proxy
-  m.call(reserveStrategy, "initialize", [
+  // encode initializer calldata
+  const initCalldata = m.encodeFunctionCall(impl, "initialize", [
     diamond,
     { token: stake },
     asset,
     assetPrice,
   ]);
+
+  // deploy ERC1967Proxy with init data
+  const proxy = m.contract("ERC1967Proxy", [impl, initCalldata]);
+  const reserveStrategy = m.contractAt("MockReserveStrategy", proxy);
 
   return { proxy, reserveStrategy };
 });

--- a/ignition/modules/test/MockReserveStrategy.ts
+++ b/ignition/modules/test/MockReserveStrategy.ts
@@ -7,10 +7,20 @@ const ReserveStrategyModule = buildModule("ReserveStrategyModule", (m) => {
   const asset = m.getParameter("asset", "0x");
   const assetPrice = m.getParameter("assetPrice", parseEther("1"));
 
-  const reserveStrategy = m.contract("MockReserveStrategy", [
-    diamond, { token: stake }, asset, assetPrice,
+  const impl = m.contract("MockReserveStrategy", [], { id: "impl" });
+  const proxy = m.contract("ERC1967Proxy", [impl, "0x"]);
+
+  const reserveStrategy = m.contractAt("MockReserveStrategy", proxy);
+
+  // Initialize via the proxy
+  m.call(reserveStrategy, "initialize", [
+    diamond,
+    { token: stake },
+    asset,
+    assetPrice,
   ]);
-  return { reserveStrategy };
+
+  return { proxy, reserveStrategy };
 });
 
 export default ReserveStrategyModule;

--- a/test/shared.ts
+++ b/test/shared.ts
@@ -29,7 +29,9 @@ export async function getSigners() {
     owner, stakingManager, vaultManager, strategyManager, lumiaFactoryManager, bob, alice,
   ] = await ethers.getSigners();
 
-  return { owner, stakingManager, vaultManager, strategyManager, lumiaFactoryManager, bob, alice };
+  const strategyUpgrader = owner;
+
+  return { owner, stakingManager, vaultManager, strategyManager, strategyUpgrader, lumiaFactoryManager, bob, alice };
 }
 
 // -------------------- Currency --------------------

--- a/test/shared.ts
+++ b/test/shared.ts
@@ -105,7 +105,7 @@ export async function deployTestHyperStaking(mailboxFee: bigint) {
 
   // -------------------- Superform --------------------
 
-  const erc4626Vault = await deloyTestERC4626Vault(testUSDC);
+  const erc4626Vault = await deployTestERC4626Vault(testUSDC);
   const {
     superformFactory, superformRouter, superVault, superPositions,
   } = await deploySuperformMock(erc4626Vault);
@@ -196,7 +196,7 @@ export async function deployTestERC20(name: string, symbol: string, decimals: nu
   return testERC20;
 }
 
-export async function deloyTestERC4626Vault(asset: Contract): Promise<Contract> {
+export async function deployTestERC4626Vault(asset: Contract): Promise<Contract> {
   return ethers.deployContract("TestERC4626", [await asset.getAddress()]) as unknown as Promise<Contract>;
 }
 

--- a/test/unit/CurveStrategy.test.ts
+++ b/test/unit/CurveStrategy.test.ts
@@ -294,7 +294,7 @@ describe("CurveStrategy", function () {
       await usdc.mint(signers.alice.address, parseUnits("10000", 6));
       await usdt.mint(signers.alice.address, parseUnits("10000", 6));
 
-      const erc4626Vault = await shared.deloyTestERC4626Vault(usdc);
+      const erc4626Vault = await shared.deployTestERC4626Vault(usdc);
 
       const {
         superformFactory, superformRouter, superVault, superPositions,

--- a/test/unit/Superform.test.ts
+++ b/test/unit/Superform.test.ts
@@ -12,7 +12,7 @@ async function getMockedSuperform() {
   const [superManager, alice] = await ethers.getSigners();
 
   const testUSDC = await shared.deployTestERC20("Test USD Coin", "tUSDC", 6);
-  const erc4626Vault = await shared.deloyTestERC4626Vault(testUSDC);
+  const erc4626Vault = await shared.deployTestERC4626Vault(testUSDC);
   await testUSDC.mint(alice.address, parseUnits("1000000", 6));
 
   // --------------------

--- a/test/unit/VaultShares.test.ts
+++ b/test/unit/VaultShares.test.ts
@@ -78,7 +78,7 @@ describe("VaultShares", function () {
       // create another vault shares to check different values
 
       const strangeDecimals = 11;
-      const strangeUSDStake = await shared.deloyTestERC20("Test USD Strange Asset", "tUSSA", strangeDecimals);
+      const strangeUSDStake = await shared.deployTestERC20("Test USD Strange Asset", "tUSSA", strangeDecimals);
 
       const strangeStrategy = await shared.createReserveStrategy(
         diamond, await strangeUSDStake.getAddress(), await testReserveAsset.getAddress(), reserveAssetPrice,


### PR DESCRIPTION
All strategies now sit behind Proxy with a UUPS implementation (OZ 5.1).
- `AbstractStrategy` integrates `UUPSUpgradeable`, child strategies use a single initialize
- Added Strategy Upgrader role to HyperstakingAcl
- Updated Ignition deployment
- Small test for upgrade